### PR TITLE
Fix: remove premature no books found message while loading

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -30,6 +30,7 @@ interface SearchResponse {
 export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<BookHit[]>([]);
+  const [hasSearched, setHasSearched] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
@@ -38,6 +39,7 @@ export default function SearchPage() {
     {
       fetchPolicy: "network-only",
       onCompleted: (data) => {
+        setHasSearched(true);
         if (data && data.search && data.search.results) {
           setResults(data.search.results.hits);
         }
@@ -50,6 +52,7 @@ export default function SearchPage() {
       debounce((searchQuery: string) => {
         if (!searchQuery.trim()) {
           setResults([]);
+          setHasSearched(false);
           return;
         }
         searchBooks({ variables: { query: searchQuery } });
@@ -62,6 +65,7 @@ export default function SearchPage() {
       debouncedSearch(query);
     } else {
       setResults([]);
+      setHasSearched(false);
     }
 
     return () => {
@@ -90,6 +94,7 @@ export default function SearchPage() {
   const clearSearch = () => {
     setQuery("");
     setResults([]);
+    setHasSearched(false);
     if (searchInputRef.current) {
       searchInputRef.current.focus();
     }
@@ -186,6 +191,7 @@ export default function SearchPage() {
                 results={results}
                 query={query}
                 isLoading={isLoading}
+                hasSearched={hasSearched}
                 onBookSelect={handleBookSelect}
               />
             </div>

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -32,6 +32,7 @@ export function SearchBar() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<BookHit[]>([]);
   const [showResults, setShowResults] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
 
   const router = useRouter();
 
@@ -41,6 +42,7 @@ export function SearchBar() {
       fetchPolicy: "network-only",
       onCompleted: (data) => {
         console.log("Search completed:", data);
+        setHasSearched(true);
         if (data && data.search && data.search.results) {
           setResults(data.search.results.hits);
         }
@@ -54,6 +56,7 @@ export function SearchBar() {
       debounce((searchQuery: string) => {
         if (!searchQuery.trim()) {
           setResults([]);
+          setHasSearched(false);
           return;
         }
         searchBooks({ variables: { query: searchQuery } });
@@ -66,6 +69,7 @@ export function SearchBar() {
       debouncedSearch(query);
     } else {
       setResults([]);
+      setHasSearched(false);
     }
 
     return () => {
@@ -118,6 +122,7 @@ export function SearchBar() {
                 results={results}
                 query={query}
                 isLoading={isLoading}
+                hasSearched={hasSearched}
                 onBookSelect={handleBookSelect}
               />
             </CardContent>

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -20,10 +20,11 @@ interface SearchResultsProps {
   results: BookHit[];
   query: string;
   isLoading: boolean;
+  hasSearched: boolean;
   onBookSelect: (bookId: string) => void;
 }
 
-export function SearchResults({ results, query, isLoading, onBookSelect }: SearchResultsProps) {
+export function SearchResults({ results, query, isLoading, hasSearched, onBookSelect }: SearchResultsProps) {
   if (isLoading) {
     return (
       <div className="p-4 text-center text-sm text-muted-foreground">
@@ -71,7 +72,7 @@ export function SearchResults({ results, query, isLoading, onBookSelect }: Searc
     );
   }
 
-  if (query && !isLoading) {
+  if (hasSearched && !isLoading && results.length === 0) {
     return (
       <div className="p-4 text-center text-sm text-muted-foreground">
         No books found for "{query}"


### PR DESCRIPTION
Due to state management issues, a "No books found" would flicker while loading results. This fix removes that