### PR TITLE
Feat: resize explore page for mobile view

### DIFF
--- a/components/BookCard.tsx
+++ b/components/BookCard.tsx
@@ -54,11 +54,11 @@ export default function BookCard({
       <div className="absolute -inset-0.5 bg-gradient-to-r from-teal-400 via-blue-500 to-purple-500 rounded-xl opacity-0 group-hover:opacity-100 transition-all duration-500 blur-sm" />
 
       <div
-        className={`relative overflow-hidden rounded-xl transition-all duration-500 w-[220px] bg-slate-900 border border-slate-700/50 group-hover:border-slate-600 shadow-xl group-hover:shadow-2xl ${
+        className={`relative overflow-hidden rounded-xl transition-all duration-500 w-[120px] sm:w-[150px] md:w-[180px] bg-slate-900 border border-slate-700/50 group-hover:border-slate-600 shadow-xl group-hover:shadow-2xl ${
           onClick || href ? "cursor-pointer" : "cursor-default"
         }`}
       >
-        <div className="relative w-full h-[320px]">
+        <div className="relative w-full h-[180px] sm:h-[220px] md:h-[260px]">
           {/* Image or placeholder */}
           {normalizedBook.imageUrl && !hasError ? (
             <Image
@@ -68,14 +68,14 @@ export default function BookCard({
               }`}
               src={normalizedBook.imageUrl}
               fill
-              sizes="220px"
+              sizes="(max-width: 640px) 120px, (max-width: 768px) 150px, 180px"
               onLoad={handleImageLoad}
               onError={handleImageError}
             />
           ) : (
             <div className="w-full h-full bg-gradient-to-br from-slate-800 to-slate-900 flex flex-col items-center justify-center text-slate-400">
-              <ImageIcon className="w-12 h-12 mb-2 opacity-60" />
-              <p className="text-xs text-center px-2 opacity-60">
+              <ImageIcon className="w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 mb-2 opacity-60" />
+              <p className="text-[10px] sm:text-xs text-center px-2 opacity-60">
                 No Image Available
               </p>
             </div>
@@ -89,27 +89,27 @@ export default function BookCard({
           )}
 
           {/* Action buttons - appear on hover */}
-          <div className="absolute top-3 right-3 flex gap-2 opacity-0 group-hover:opacity-100 transition-all duration-300 translate-y-2 group-hover:translate-y-0">
-            <button className="w-8 h-8 bg-slate-900/80 backdrop-blur-sm border border-slate-600/50 rounded-full flex items-center justify-center text-slate-300 hover:text-red-400 hover:border-red-400/50 transition-all duration-200">
-              <Heart className="w-4 h-4" />
+          <div className="absolute top-2 right-2 sm:top-3 sm:right-3 flex gap-1 sm:gap-2 opacity-0 group-hover:opacity-100 transition-all duration-300 translate-y-2 group-hover:translate-y-0">
+            <button className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8 bg-slate-900/80 backdrop-blur-sm border border-slate-600/50 rounded-full flex items-center justify-center text-slate-300 hover:text-red-400 hover:border-red-400/50 transition-all duration-200">
+              <Heart className="w-3 h-3 sm:w-3.5 sm:h-3.5 md:w-4 md:h-4" />
             </button>
-            <button className="w-8 h-8 bg-slate-900/80 backdrop-blur-sm border border-slate-600/50 rounded-full flex items-center justify-center text-slate-300 hover:text-yellow-400 hover:border-yellow-400/50 transition-all duration-200">
-              <Star className="w-4 h-4" />
+            <button className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8 bg-slate-900/80 backdrop-blur-sm border border-slate-600/50 rounded-full flex items-center justify-center text-slate-300 hover:text-yellow-400 hover:border-yellow-400/50 transition-all duration-200">
+              <Star className="w-3 h-3 sm:w-3.5 sm:h-3.5 md:w-4 md:h-4" />
             </button>
           </div>
 
           {/* Title and author container - appears on hover */}
-          <div className="absolute inset-x-3 bottom-3 overflow-hidden rounded-xl backdrop-blur-xl bg-slate-900/90 border border-slate-600/30 opacity-0 transition-all duration-500 group-hover:opacity-100 translate-y-4 group-hover:translate-y-0">
-            <div className="p-4">
-              <p className="text-sm font-semibold text-white text-center line-clamp-2 mb-2">
+          <div className="absolute inset-x-2 bottom-2 sm:inset-x-3 sm:bottom-3 overflow-hidden rounded-xl backdrop-blur-xl bg-slate-900/90 border border-slate-600/30 opacity-0 transition-all duration-500 group-hover:opacity-100 translate-y-4 group-hover:translate-y-0">
+            <div className="p-2 sm:p-3 md:p-4">
+              <p className="text-xs sm:text-sm font-semibold text-white text-center line-clamp-2 mb-1 sm:mb-2">
                 {normalizedBook.title}
               </p>
-              <p className="text-xs text-slate-300 text-center line-clamp-1 mb-3">
+              <p className="text-[10px] sm:text-xs text-slate-300 text-center line-clamp-1 mb-2 sm:mb-3">
                 {authorText}
               </p>
               {normalizedBook.pageCount && (
-                <div className="flex items-center justify-center text-xs text-slate-400">
-                  <BookOpen className="w-3 h-3 mr-1.5 text-teal-400" />
+                <div className="flex items-center justify-center text-[10px] sm:text-xs text-slate-400">
+                  <BookOpen className="w-2.5 h-2.5 sm:w-3 sm:h-3 mr-1 sm:mr-1.5 text-teal-400" />
                   <span>{normalizedBook.pageCount} pages</span>
                 </div>
               )}

--- a/components/ScrollableBookSection.tsx
+++ b/components/ScrollableBookSection.tsx
@@ -18,35 +18,37 @@ export default function ScrollableBookSection({
 
   const scrollLeft = () => {
     if (scrollRef.current) {
-      scrollRef.current.scrollBy({ left: -220, behavior: "smooth" });
+      const scrollAmount = window.innerWidth < 640 ? -130 : window.innerWidth < 768 ? -160 : -190;
+      scrollRef.current.scrollBy({ left: scrollAmount, behavior: "smooth" });
     }
   };
 
   const scrollRight = () => {
     if (scrollRef.current) {
-      scrollRef.current.scrollBy({ left: 220, behavior: "smooth" });
+      const scrollAmount = window.innerWidth < 640 ? 130 : window.innerWidth < 768 ? 160 : 190;
+      scrollRef.current.scrollBy({ left: scrollAmount, behavior: "smooth" });
     }
   };
 
   if (books.length === 0) return null;
 
   return (
-    <div className="mb-16 relative">
+    <div className="mb-8 sm:mb-12 md:mb-16 relative">
       {/* Section Header */}
-      <div className="mb-8 relative">
-        <div className="flex items-center gap-3 mb-2">
-          <div className="w-1 h-8 bg-gradient-to-b from-teal-500 to-purple-500 dark:from-teal-400 dark:to-purple-400 rounded-full" />
-          <h2 className="text-3xl font-bold text-foreground">{title}</h2>
-          <Sparkles className="w-6 h-6 text-teal-500 dark:text-teal-400 animate-pulse" />
+      <div className="mb-4 sm:mb-6 md:mb-8 relative">
+        <div className="flex items-center gap-2 sm:gap-3 mb-2">
+          <div className="w-0.5 sm:w-1 h-6 sm:h-8 bg-gradient-to-b from-teal-500 to-purple-500 dark:from-teal-400 dark:to-purple-400 rounded-full" />
+          <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground">{title}</h2>
+          <Sparkles className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6 text-teal-500 dark:text-teal-400 animate-pulse" />
         </div>
-        <div className="w-24 h-1 bg-gradient-to-r from-teal-500 to-purple-500 dark:from-teal-400 dark:to-purple-400 rounded-full ml-7" />
+        <div className="w-16 sm:w-20 md:w-24 h-0.5 sm:h-1 bg-gradient-to-r from-teal-500 to-purple-500 dark:from-teal-400 dark:to-purple-400 rounded-full ml-4 sm:ml-6 md:ml-7" />
       </div>
-      <div className="relative scroll-section-container group/scroll bg-gradient-to-r from-muted/30 via-muted/20 to-muted/30 rounded-2xl p-6 border border-border/20 backdrop-blur-sm">
+      <div className="relative scroll-section-container group/scroll bg-gradient-to-r from-muted/30 via-muted/20 to-muted/30 rounded-xl sm:rounded-2xl p-3 sm:p-4 md:p-6 border border-border/20 backdrop-blur-sm">
         {/* Left Arrow */}
         <Button
           variant="outline"
           size="icon"
-          className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-background/90 backdrop-blur-sm border-teal-500/30 dark:border-teal-400/30 hover:border-teal-500 dark:hover:border-teal-400 hover:bg-teal-500/10 dark:hover:bg-teal-400/10 text-teal-500 dark:text-teal-400 opacity-0 group-hover/scroll:opacity-100 transition-all duration-300 shadow-lg"
+          className="absolute left-1 sm:left-2 top-1/2 -translate-y-1/2 z-10 bg-background/90 backdrop-blur-sm border-teal-500/30 dark:border-teal-400/30 hover:border-teal-500 dark:hover:border-teal-400 hover:bg-teal-500/10 dark:hover:bg-teal-400/10 text-teal-500 dark:text-teal-400 opacity-0 group-hover/scroll:opacity-100 transition-all duration-300 shadow-lg hidden sm:flex"
           onClick={scrollLeft}
         >
           <ChevronLeft className="h-5 w-5" />
@@ -56,7 +58,7 @@ export default function ScrollableBookSection({
         <Button
           variant="outline"
           size="icon"
-          className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-background/90 backdrop-blur-sm border-teal-500/30 dark:border-teal-400/30 hover:border-teal-500 dark:hover:border-teal-400 hover:bg-teal-500/10 dark:hover:bg-teal-400/10 text-teal-500 dark:text-teal-400 opacity-0 group-hover/scroll:opacity-100 transition-all duration-300 shadow-lg"
+          className="absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 z-10 bg-background/90 backdrop-blur-sm border-teal-500/30 dark:border-teal-400/30 hover:border-teal-500 dark:hover:border-teal-400 hover:bg-teal-500/10 dark:hover:bg-teal-400/10 text-teal-500 dark:text-teal-400 opacity-0 group-hover/scroll:opacity-100 transition-all duration-300 shadow-lg hidden sm:flex"
           onClick={scrollRight}
         >
           <ChevronRight className="h-5 w-5" />
@@ -65,7 +67,7 @@ export default function ScrollableBookSection({
         {/* Scrollable container */}
         <div
           ref={scrollRef}
-          className="flex gap-6 overflow-x-auto overflow-y-hidden scrollbar-hide px-8 py-4"
+          className="flex gap-3 sm:gap-4 md:gap-6 overflow-x-auto overflow-y-hidden scrollbar-hide px-2 sm:px-4 md:px-8 py-2 sm:py-3 md:py-4"
           style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
         >
           {books.map((book) => (


### PR DESCRIPTION
Resized the ScrollableBookSections and BookCards to look better on Mobile. I also ended up resizing to be smaller at all breakpoints.

![image](https://github.com/user-attachments/assets/c7efd8a1-898d-4c5a-86b0-e7427797d076)
